### PR TITLE
Disable setting of RTC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ EXPOSE 123/udp
 HEALTHCHECK CMD chronyc tracking || exit 1
 
 # start
-CMD [ "/usr/sbin/chronyd", "-d", "-s"]
+CMD [ "/usr/sbin/chronyd", "-d", "-s", "-x"]

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ After changes to `FAKETIME` the NTP service has to be restarted:
 
 Alternatively you can run the service purely with Docker providing the complete setup in the parameters of `docker run`:
 
-    docker build -t ntp-mock:latest . && docker run -p 127.0.0.1:123:123/udp --env FAKETIME=+15d --cap-add SYS_TIME ntp-mock:latest
+    docker build -t ntp-mock:latest . && docker run -p 127.0.0.1:123:123/udp --env FAKETIME=+15d ntp-mock:latest
 

--- a/chrony.conf
+++ b/chrony.conf
@@ -1,7 +1,6 @@
 # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#_isolated_networks
 
 local stratum 8
-rtcsync
 
 # allow clients from all sources
 allow 0.0.0.0/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,3 @@ services:
     ports:
       - "${EXT_IP}:123:123/udp"
     env_file: .env
-    cap_add:
-      - SYS_TIME


### PR DESCRIPTION
This removes the need for the SYS_TIME capability and prevents the container from making changes to local system.

I think this is desired, as this projects purpose is probably to test devices connected over the network. (This is not stated anywhere, but I assume it. When testing the local system, one wouldn't need to run a NTP server at all and could just set the time freely.)

Merge if you like but feel free to decline. :)

Anyway, thanks a lot for coming up with this. By the way, which license is this repo under?

Regards,
Manuel